### PR TITLE
drag & drop feature inspired by Flutter (ver. ScreenMaganer)

### DIFF
--- a/examples/uix/draggable/classifying_food_scrmgr.py
+++ b/examples/uix/draggable/classifying_food_scrmgr.py
@@ -1,0 +1,115 @@
+from kivy.properties import StringProperty, ColorProperty
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.factory import Factory
+import asynckivy as ak
+
+from kivyx.uix.boxlayout import KXBoxLayout
+from kivyx.uix.draggable import KXDroppableBehavior, KXDraggableScreenManager
+
+
+KV_CODE = '''
+<DroppableArea>:
+    drag_classes: ['item', ]
+    canvas.before:
+        Color:
+            rgba: self.line_color
+        Line:
+            width: 2
+            rectangle: [*self.pos, *self.size, ]
+<DraggableItem>:
+    drag_cls: 'item'
+    Screen:
+        name: 'default'
+        canvas.before:
+            Color:
+                rgba: 1, 1, 1, 1
+            Line:
+                dash_length: 4
+                dash_offset: 4
+                rectangle: [0, 0, *self.size, ]
+        Label:
+            font_size: 30
+            text: root.name
+            opacity: .4 if root.is_being_dragged else 1.
+    Screen:
+        name: 'remains_behind'
+
+KXBoxLayout:
+    orientation: 'tb'
+    spacing: 50
+    KXBoxLayout:
+        orientation: 'lr'
+        padding: 20
+        spacing: 20
+        DroppableArea:
+            line_color: "#FF0000"
+            color_cls: 'red'
+        DroppableArea:
+            line_color: "#00FF00"
+            color_cls: 'yellow'
+        DroppableArea:
+            line_color: "#0000FF"
+            color_cls: 'blue'
+    GridLayout:
+        id: where_the_items_initially_live
+        cols: 3
+        padding: 20
+        spacing: 20
+'''
+
+
+class DraggableItem(KXDraggableScreenManager):
+    name = StringProperty()
+    color_cls = StringProperty()
+
+    def on_drag_cancel(self, droppable):
+        if droppable is None:
+            return
+        print(f"Incorrect! {self.name} is not {droppable.color_cls}")
+
+    def on_drag_complete(self, droppable):
+        print("Correct")
+
+
+class DroppableArea(KXDroppableBehavior, Factory.FloatLayout):
+    line_color = ColorProperty()
+    color_cls = StringProperty()
+
+    def will_accept_drag(self, draggable):
+        return draggable.color_cls == self.color_cls
+
+    def accept_drag(self, draggable):
+        draggable.parent.remove_widget(draggable)
+        draggable.pos_hint = {'x': 0, 'y': 0, }
+        draggable.size_hint = (1, 1, )
+        self.add_widget(draggable)
+        ak.start(self._dispose_item(draggable))
+
+    async def _dispose_item(self, draggable):
+        await ak.animate(draggable, opacity=0, d=.5)
+        self.remove_widget(draggable)
+
+
+class SampleApp(App):
+    def build(self):
+        from random import shuffle
+        root = Builder.load_string(KV_CODE)
+        items = [
+            DraggableItem(name=name, color_cls=color_cls)
+            for color_cls, names in {
+                'red': ('apple', 'strawberry', 'tomato', ),
+                'yellow': ('lemon', 'banana', 'mango', ),
+                'blue': ('grape', 'blueberry', ),
+            }.items()
+            for name in names
+        ]
+        shuffle(items)
+        add_widget = root.ids.where_the_items_initially_live.add_widget
+        for item in items:
+            add_widget(item)
+        return root
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/examples/uix/draggable/test_droppable_areas_are_overlapping_each_other_scrmgr.py
+++ b/examples/uix/draggable/test_droppable_areas_are_overlapping_each_other_scrmgr.py
@@ -1,0 +1,59 @@
+from kivy.properties import ColorProperty
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.factory import Factory
+
+from kivyx.uix.draggable import KXDroppableBehavior, KXDraggableScreenManager
+
+
+KV_CODE = '''
+<DroppableArea>:
+    drag_classes: ['test', ]
+    canvas.before:
+        Color:
+            rgba: self.background_color
+        Rectangle:
+            pos: self.pos
+            size: self.size
+
+DroppableArea:
+    background_color: "#000000"
+    DroppableArea:
+        background_color: "#111155"
+        size_hint: .7, .5
+        pos_hint: {'center': (.6, .4, ), }
+    DroppableArea:
+        background_color: "#551111"
+        size_hint: .7, .5
+        pos_hint: {'center': (.4, .6, ), }
+    KXDraggableScreenManager:
+        id: draggable
+        drag_cls: 'test'
+        size_hint: None, None
+        size: 100, 100
+        pos_hint: {'x': 0, 'y': 0, }
+        Screen:
+            name: 'remains_behind'
+        Screen:
+            name: 'default'
+            Label:
+                font_size: 100
+                text: 'A'
+                opacity: .3 if draggable.is_being_dragged else 1.
+'''
+
+
+class DroppableArea(KXDroppableBehavior, Factory.FloatLayout):
+    background_color = ColorProperty()
+    def add_widget(self, widget, *args, **kwargs):
+        widget.pos_hint = {'x': 0, 'y': 0, }
+        return super().add_widget(widget, *args, **kwargs)
+
+
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
+
+
+if __name__ == '__main__':
+    SampleApp().run()


### PR DESCRIPTION
This provides the same feature as #5 does. The difference is that this one using `ScreenManager`. 

As a result, the following code

```yaml
<DraggableItem@KXDraggable>:
    widget_default: default
    widget_below_finger: below_finger
    widget_remains_behind: remains_behind
    Widget:
        id: default
    Widget:
        id: below_finger
    Widget:
        id: remains_behind
```

can be written like this:

```yaml
<DraggableItem@KXDraggableScreenManager>:
    Screen:
        name: 'default'
        Widget:
    Screen:
        name: 'below_finger'
        Widget:
    Screen:
        name: 'remains_behind'
        Widget:
```