### PR TITLE
make KXDrawer openable/closeable by method call

### DIFF
--- a/examples/uix/drawer/_test.py
+++ b/examples/uix/drawer/_test.py
@@ -96,9 +96,16 @@ BoxLayout:
         size_hint_x: .1
         size_hint_min_x: 100
         orientation: 'vertical'
+        spacing: dp(4)
         Button:
             text: 'disappear()'
             on_press: drawer.disappear()
+        Button:
+            text: 'open()'
+            on_press: drawer.open()
+        Button:
+            text: 'close()'
+            on_press: drawer.close()
         Label:
             text: 'anchor'
             color: 0, 1, 0, 1

--- a/kivyx/uix/drawer.py
+++ b/kivyx/uix/drawer.py
@@ -193,8 +193,9 @@ class KXDrawer(RelativeLayout):
             self.dispatch('on_close')
 
     def open(self, *args, **kwargs):
-        '''Opens a drawer. This method doesn't use the arguments at all, so
-        you can bind it to events without putting a lambda function.
+        '''Opens the drawer. This method can take any argument but doesn't
+        use it at all, so you can bind the method to any events without
+        putting an additional function.
 
             drawer = KXDrawer()
             button = Button()
@@ -203,8 +204,9 @@ class KXDrawer(RelativeLayout):
         self._being_asked_to_open.set()
 
     def close(self, *args, **kwargs):
-        '''Closes a drawer. This method doesn't use the arguments at all, so
-        you can bind it to events without putting a lambda function.
+        '''Closes a drawer. This method can take any argument but doesn't
+        use it at all, so you can bind the method to any events without
+        putting an additional function.
 
             drawer = KXDrawer()
             button = Button()

--- a/kivyx/uix/drawer.py
+++ b/kivyx/uix/drawer.py
@@ -194,7 +194,7 @@ class KXDrawer(RelativeLayout):
 
     def open(self, *args, **kwargs):
         '''Opens a drawer. This method doesn't use the arguments at all, so
-        you can bind it to events without putting lambda function.
+        you can bind it to events without putting a lambda function.
 
             drawer = KXDrawer()
             button = Button()
@@ -204,7 +204,7 @@ class KXDrawer(RelativeLayout):
 
     def close(self, *args, **kwargs):
         '''Closes a drawer. This method doesn't use the arguments at all, so
-        you can bind it to events without putting lambda function.
+        you can bind it to events without putting a lambda function.
 
             drawer = KXDrawer()
             button = Button()

--- a/kivyx/uix/drawer.py
+++ b/kivyx/uix/drawer.py
@@ -193,9 +193,9 @@ class KXDrawer(RelativeLayout):
             self.dispatch('on_close')
 
     def open(self, *args, **kwargs):
-        '''Opens the drawer. This method can take any argument but doesn't
-        use it at all, so you can bind the method to any events without
-        putting an additional function.
+        '''Opens the drawer. This method can take any number of arguments
+        but doesn't use those at all, so you can bind the method to any event
+        without putting an additional function.
 
             drawer = KXDrawer()
             button = Button()
@@ -204,9 +204,9 @@ class KXDrawer(RelativeLayout):
         self._being_asked_to_open.set()
 
     def close(self, *args, **kwargs):
-        '''Closes a drawer. This method can take any argument but doesn't
-        use it at all, so you can bind the method to any events without
-        putting an additional function.
+        '''Closes the drawer. This method can take any number of arguments
+        but doesn't use those at all, so you can bind the method to any event
+        without putting an additional function.
 
             drawer = KXDrawer()
             button = Button()

--- a/kivyx/uix/drawer.py
+++ b/kivyx/uix/drawer.py
@@ -73,7 +73,6 @@ class KXDrawerTab(ButtonBehavior, Label):
     __ = None
 
 
-
 class KXDrawer(RelativeLayout):
     '''A nifty drawer.
 
@@ -112,6 +111,8 @@ class KXDrawer(RelativeLayout):
     def __init__(self, **kwargs):
         self._is_moving_to_the_top = False
         self._trigger_reset = trigger = Clock.create_trigger(self.reset, 0)
+        self._being_asked_to_open = ak.Event()
+        self._being_asked_to_close = ak.Event()
         super().__init__(**kwargs)
         self.fbind('anchor', trigger)
         trigger()
@@ -155,8 +156,14 @@ class KXDrawer(RelativeLayout):
 
         tab.icon_angle = icon_angle_c
         ph[pos_key_c] = ph_value
+
+        being_asked_to_close = self._being_asked_to_close
+        being_asked_to_open = self._being_asked_to_open
         while True:
-            await ak.event(tab, 'on_press')
+            await ak.or_(
+                ak.event(tab, 'on_press'),
+                being_asked_to_open.wait(),
+            )
             self.dispatch('on_pre_open')
             if self.top_when_opened:
                 self._is_moving_to_the_top = True
@@ -167,18 +174,43 @@ class KXDrawer(RelativeLayout):
             await ak.animate(
                 self, d=self.duration,
                 **{pos_key_o: _get_pos_value_in_local_coordinates()})
+            being_asked_to_close.clear()
             await ak.animate(tab, d=self.duration, icon_angle=icon_angle_o)
             ph[pos_key_o] = ph_value
             self.dispatch('on_open')
-            await ak.event(tab, 'on_press')
+            await ak.or_(
+                ak.event(tab, 'on_press'),
+                being_asked_to_close.wait(),
+            )
             self.dispatch('on_pre_close')
             del ph[pos_key_o]
             await ak.animate(
                 self, d=self.duration,
                 **{pos_key_c: _get_pos_value_in_local_coordinates()})
+            being_asked_to_open.clear()
             await ak.animate(tab, d=self.duration, icon_angle=icon_angle_c)
             ph[pos_key_c] = ph_value
             self.dispatch('on_close')
+
+    def open(self, *args, **kwargs):
+        '''Opens a drawer. This method doesn't use the arguments at all, so
+        you can bind it to events without putting lambda function.
+
+            drawer = KXDrawer()
+            button = Button()
+            button.bind(on_press=drawer.open)
+        '''
+        self._being_asked_to_open.set()
+
+    def close(self, *args, **kwargs):
+        '''Closes a drawer. This method doesn't use the arguments at all, so
+        you can bind it to events without putting lambda function.
+
+            drawer = KXDrawer()
+            button = Button()
+            button.bind(on_press=drawer.close)
+        '''
+        self._being_asked_to_close.set()
 
     def on_pre_open(self):
         pass


### PR DESCRIPTION
Currently `KXDrawer` can be opened/closed by user operations, (by pressing the tab). This PR makes it possible by calling methods, `open()` and `close()`.

```python3
drawer = KXDrawer()
button = Button()
button.bind(on_press=drawer.open)
button2 = Button()
button2.bind(on_press=drawer.close)
```