### PR TITLE
add KXModestDraggable

### DIFF
--- a/examples/uix/draggable/test_modest_draggable.py
+++ b/examples/uix/draggable/test_modest_draggable.py
@@ -39,7 +39,7 @@ DroppableArea:
         text:
             (
             "You can press the button if it already being dragged. (do multi touch)\\n"
-            "You can press the button if 'allows_drag' is False.\\n"
+            "You can press the button if 'allows_drag' is OFF.\\n"
             )
 '''
 

--- a/examples/uix/draggable/test_modest_draggable.py
+++ b/examples/uix/draggable/test_modest_draggable.py
@@ -1,0 +1,53 @@
+from kivy.properties import StringProperty, ColorProperty
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.factory import Factory
+import asynckivy as ak
+
+from kivyx.uix.boxlayout import KXBoxLayout
+from kivyx.uix.draggable import KXDroppableBehavior, KXModestDraggable
+
+
+KV_CODE = '''
+<DroppableArea@KXDroppableBehavior+FloatLayout>:
+    drag_classes: ['test', ]
+<DraggableButton@KXModestDraggable>:
+    drag_cls: 'test'
+    widget_default: default
+    Button:
+        id: default
+        text: 'Press me!'
+DroppableArea:
+    KXBoxLayout:
+        orientation: 'tb'
+        pos_hint: {'right': 1, 'y': 0, }
+        size_hint: None, None
+        size: 200, 100
+        Label:
+            text: 'allows_drag'
+            color: [0, 1, 0, 1, ]
+        Switch:
+            id: allows_drag
+            active: True
+    DraggableButton:
+        size_hint: None, None
+        size: 200, 200
+        allows_drag: allows_drag.active
+    Label:
+        pos_hint: {'x': 0, 'top': 1, }
+        size_hint: 1, .5
+        text:
+            (
+            "You can press the button if it already being dragged. (do multi touch)\\n"
+            "You can press the button if 'allows_drag' is False.\\n"
+            )
+'''
+
+
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/kivyx/uix/draggable.py
+++ b/kivyx/uix/draggable.py
@@ -328,6 +328,7 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
     allows_drag = BooleanProperty(True)
     '''Same as KXDragReceiver's '''
 
+    # some methods are completely the same as KXDraggable's, so use it.
     __on_pos = KXDraggable._KXDraggable__on_pos
     __on_size = KXDraggable._KXDraggable__on_size
     __on_widget_default = KXDraggable._KXDraggable__on_widget_default

--- a/kivyx/uix/draggable.py
+++ b/kivyx/uix/draggable.py
@@ -328,6 +328,11 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
     allows_drag = BooleanProperty(True)
     '''Same as KXDragReceiver's '''
 
+    __on_pos = KXDraggable._KXDraggable__on_pos
+    __on_size = KXDraggable._KXDraggable__on_size
+    __on_widget_default = KXDraggable._KXDraggable__on_widget_default
+    # real_add_widget = KXDraggable.real_add_widget  # not allowed!!
+
     def __init__(self, **kwargs):
         f = self.fbind
         f('pos', KXModestDraggable.__on_pos)
@@ -345,24 +350,6 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
         self.is_being_dragged = True
         self.dispatch('on_drag_start')
         ak.start(self._handle_touch(touch))
-
-    def __on_pos(self, pos):
-        children = self.children
-        if not children:
-            return
-        children[0].pos = pos
-
-    def __on_size(self, size):
-        children = self.children
-        if not children:
-            return
-        children[0].size = size
-
-    def __on_widget_default(self, widget):
-        if not self.is_being_dragged:
-            self.real_clear_widgets()
-            if widget is not None:
-                self.real_add_widget(widget)
 
     def real_add_widget(self, widget, *args, **kwargs):
         widget.pos = self.pos

--- a/kivyx/uix/draggable.py
+++ b/kivyx/uix/draggable.py
@@ -9,7 +9,10 @@ Inspired by
 This module is highly experimental.
 '''
 
-__all__ = ('KXDraggable', 'KXDraggableScreenManager', 'KXDroppableBehavior', )
+__all__ = (
+    'KXDraggable', 'KXDraggableScreenManager', 'KXDroppableBehavior',
+    'KXModestDraggable',
+)
 
 from kivy.properties import (
     ObjectProperty, NumericProperty, BooleanProperty, ListProperty,
@@ -293,6 +296,158 @@ class KXDroppableBehavior:
         if parent is not None:
             parent.remove_widget(draggable)
         self.add_widget(draggable)
+
+
+class KXModestDraggable(KXFakeChildrenBehavior, Widget):
+    '''The differences from KXDraggable.
+
+    - Faster.
+    - Doesn't have `on_drag_is_about_to_start` event.
+    - Immediately treats touches as drag if it happens inside the widget.
+    '''
+    __events__ = ('on_drag_start', 'on_drag_complete', 'on_drag_cancel', )
+
+    drag_cls = StringProperty()
+    '''Same as KXDraggable's '''
+
+    widget_default = ObjectProperty(None, allownone=True)
+    '''Same as KXDraggable's '''
+
+    widget_below_finger = ObjectProperty(None, allownone=True)
+    '''Same as KXDraggable's '''
+
+    widget_remains_behind = ObjectProperty(None, allownone=True)
+    '''Same as KXDraggable's '''
+
+    is_being_dragged = BooleanProperty(False)
+    '''Same as KXDraggable's '''
+
+    duration_of_cancel_anim = NumericProperty(.1)
+    '''Same as KXDraggable's '''
+
+    allows_drag = BooleanProperty(True)
+    '''Same as KXDragReceiver's '''
+
+    def __init__(self, **kwargs):
+        f = self.fbind
+        f('pos', KXModestDraggable.__on_pos)
+        f('size', KXModestDraggable.__on_size)
+        f('widget_default', KXModestDraggable.__on_widget_default)
+        super().__init__(**kwargs)
+
+    def on_touch_down(self, touch):
+        if (not self.allows_drag) or \
+                self.is_being_dragged or \
+                (not self.widget_default) or \
+                touch.is_mouse_scrolling or \
+                (not self.collide_point(*touch.opos)):
+            return super().on_touch_down(touch)
+        self.is_being_dragged = True
+        self.dispatch('on_drag_start')
+        ak.start(self._handle_touch(touch))
+
+    def __on_pos(self, pos):
+        children = self.children
+        if not children:
+            return
+        children[0].pos = pos
+
+    def __on_size(self, size):
+        children = self.children
+        if not children:
+            return
+        children[0].size = size
+
+    def __on_widget_default(self, widget):
+        if not self.is_being_dragged:
+            self.real_clear_widgets()
+            if widget is not None:
+                self.real_add_widget(widget)
+
+    def real_add_widget(self, widget, *args, **kwargs):
+        widget.pos = self.pos
+        widget.size = self.size
+        return super().real_add_widget(widget, *args, **kwargs)
+
+    async def _handle_touch(self, touch):
+        from kivy.core.window import Window
+        from kivyx.utils import strip_proxy_ref
+        offset_x = touch.ox - self.x
+        offset_y = touch.oy - self.y
+        _widget_default = strip_proxy_ref(self.widget_default)
+        _widget_below_finger = strip_proxy_ref(self.widget_below_finger)
+        _widget_remains_behind = strip_proxy_ref(self.widget_remains_behind)
+        widget_below_finger = _widget_below_finger or _widget_default
+        widget_remains_behind = _widget_remains_behind or \
+            (_widget_default if _widget_below_finger else None)
+        del _widget_default
+        del _widget_below_finger
+        del _widget_remains_behind
+
+        #
+        self_to_window = self.to_window
+        touch_ud = touch.ud
+
+        # widget_remains_behind
+        self.real_clear_widgets()
+        if widget_remains_behind is not None:
+            self.real_add_widget(widget_remains_behind)
+
+        # widget_below_finger
+        touch_pos_win = self_to_window(*touch.opos)
+        widget_below_finger.size_hint = (None, None, )
+        widget_below_finger.size = self.size
+        widget_below_finger.pos_hint = {}
+        widget_below_finger.pos = (
+            touch_pos_win[0] - offset_x,
+            touch_pos_win[1] - offset_y,
+        )
+        Window.add_widget(widget_below_finger)
+
+        # mark the touch so that KXDroppableBehavior can react
+        touch_ud['kivyx_drag_cls'] = self.drag_cls
+
+        async for __ in ak.rest_of_touch_moves(self, touch):
+            touch_pos_win = self_to_window(*touch.pos)
+            widget_below_finger.pos = (
+                touch_pos_win[0] - offset_x,
+                touch_pos_win[1] - offset_y,
+            )
+        droppable = touch_ud.get('kivyx_droppable', None)
+        touch_ud['kivyx_droppable'] = None
+        cancels_drag = \
+            droppable is None or not droppable.will_accept_drag(self)
+        if cancels_drag:
+            self.dispatch('on_drag_cancel', droppable=droppable)
+            await ak.animate(
+                widget_below_finger, d=self.duration_of_cancel_anim,
+                pos=self.to_window(*self.pos), size=self.size,
+            )
+        Window.remove_widget(widget_below_finger)
+        if widget_remains_behind is not None:
+            self.real_remove_widget(widget_remains_behind)
+        if cancels_drag:
+            self.real_add_widget(self.widget_default)
+        else:
+            self.parent.remove_widget(self)
+            self.pos_hint = {}
+            self.pos = widget_below_finger.pos
+            self.size_hint = (None, None)
+            self.size = widget_below_finger.size
+            self.real_add_widget(self.widget_default)
+            Window.add_widget(self)
+            droppable.accept_drag(self)
+            self.dispatch('on_drag_complete', droppable=droppable)
+        self.is_being_dragged = False
+
+    def on_drag_start(self):
+        pass
+
+    def on_drag_complete(self, droppable):
+        pass
+
+    def on_drag_cancel(self, droppable):
+        pass
 
 
 Factory.register('KXDroppableBehavior', cls=KXDroppableBehavior)


### PR DESCRIPTION
## KXDraggableとの違い (The differences from KXDraggable)

- touchがwidget内だった場合は即dragが始まる。(`KXDraggable`は`drag_timeout`ミリ秒以内に`drag_distance`以上指が動いた時にだけdragが始まる)
- なので子widgetに`Button`を持ってたとしても通常は押せない。(即drag操作と見做すから)

## 子にtouchが伝わる条件は以下のいずれか

  - dragが無効(`allows_drag`が`False`)
  - 一つ目の指でdrag中に二つ目の指で触る

## このwidgetの使いどころ

- 子にtouchを伝える必要が全く無い場合
- drag操作の遅延が致命的な時。例えばrhythm game。