### PR TITLE
support multiple ways to initiate drag

### DIFF
--- a/examples/uix/behaviors/dragreceiver/_test.py
+++ b/examples/uix/behaviors/dragreceiver/_test.py
@@ -1,0 +1,75 @@
+from kivy.properties import BooleanProperty
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.factory import Factory
+from kivy.uix.behaviors.touchripple import TouchRippleButtonBehavior
+
+from kivyx.uix.behaviors.dragreceiver import KXDragReceiver
+
+
+class DraggableButton(KXDragReceiver, TouchRippleButtonBehavior, Factory.Label):
+    is_being_dragged = BooleanProperty(False)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fbind(
+            'on_drag_is_about_to_start',
+            lambda w, t: w.is_being_dragged,
+        )
+
+    def on_drag_touch_down(self, touch):
+        self.is_being_dragged = True
+        self._ctx = {
+            'offset_x': touch.ox - self.x,
+            'offset_y': touch.oy - self.y,
+        }
+
+    def on_drag_touch_move(self, touch):
+        _ctx = self._ctx
+        self.pos = (
+            touch.x - _ctx['offset_x'],
+            touch.y - _ctx['offset_y'],
+        )
+
+    def on_drag_touch_up(self, touch):
+        self.is_being_dragged = False
+
+
+KV_CODE = '''
+<DraggableButton>:
+    text: ('(dragging)\\n' if self.is_being_dragged else '') + self.drag_trigger
+    halign: 'center'
+    color: 1, 1, 0, 1
+    size: 200, 100
+    ripple_fade_from_alpha: .2
+    ripple_fade_to_alpha: .4
+    canvas.before:
+        Color:
+            rgba: 1, 1, 1, 1
+        Line:
+            rectangle: [*self.pos, *self.size, ]
+
+
+Widget:
+    DraggableButton:
+        drag_trigger: 'classic'
+    DraggableButton:
+        drag_trigger: 'long_press'
+        x: 400
+    DraggableButton:
+        drag_trigger: 'immediate'
+        y: 300
+    DraggableButton:
+        drag_trigger: 'none'
+        x: 400
+        y: 300
+'''
+
+
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/examples/uix/behaviors/dragreceiver/implementing_the_dragbehavior.py
+++ b/examples/uix/behaviors/dragreceiver/implementing_the_dragbehavior.py
@@ -30,6 +30,7 @@ class DragBehavior(KXDragReceiver):
     _ctx = None
 
     def __init__(self, **kwargs):
+        kwargs.setdefault('eats_touch', True)
         super().__init__(**kwargs)
         self.fbind(
             'on_drag_is_about_to_start',
@@ -45,6 +46,7 @@ class DragBehavior(KXDragReceiver):
         return (x < ox <= x + w) and (y < oy <= y + h)
 
     def on_drag_touch_down(self, touch):
+        self.drag_trigger = 'none'
         self._ctx = {
             'offset_x': touch.ox - self.x,
             'offset_y': touch.oy - self.y,
@@ -58,6 +60,7 @@ class DragBehavior(KXDragReceiver):
         )
 
     def on_drag_touch_up(self, touch):
+        self.drag_trigger = 'classic'
         self._ctx = None
 
 
@@ -69,9 +72,9 @@ KV_CODE = '''
 <DraggableWidget>:
     size: 200, 100
     orientation: 'tb'
-    drag_rectangle: [*draggable.pos, *draggable.size, ]
+    drag_rectangle: [*draggable_area.pos, *draggable_area.size, ]
     Button:
-        id: draggable
+        id: draggable_area
         text: 'draggable area'
     Button:
         text: 'non-draggable area'

--- a/examples/uix/draggable/classifying_food.py
+++ b/examples/uix/draggable/classifying_food.py
@@ -19,6 +19,7 @@ KV_CODE = '''
             rectangle: [*self.pos, *self.size, ]
 <DraggableItem>:
     drag_cls: 'item'
+    drag_trigger: 'immediate'
     widget_default: default
     Label:
         id: default

--- a/examples/uix/draggable/classifying_food_scrmgr.py
+++ b/examples/uix/draggable/classifying_food_scrmgr.py
@@ -19,6 +19,7 @@ KV_CODE = '''
             rectangle: [*self.pos, *self.size, ]
 <DraggableItem>:
     drag_cls: 'item'
+    drag_trigger: 'immediate'
     Screen:
         name: 'default'
         canvas.before:

--- a/examples/uix/draggable/reacting_to_entering_and_leaving.py
+++ b/examples/uix/draggable/reacting_to_entering_and_leaving.py
@@ -23,6 +23,7 @@ KV_CODE = '''
 
 <Draggable@KXDraggable>:
     widget_default: default
+    drag_trigger: 'immediate'
     Label:
         id: default
         text: root.drag_cls

--- a/examples/uix/draggable/test_modest_draggable.py
+++ b/examples/uix/draggable/test_modest_draggable.py
@@ -16,7 +16,7 @@ KV_CODE = '''
     widget_default: default
     Button:
         id: default
-        text: 'Press me!'
+        text: 'being dragged' if root.is_being_dragged else 'not being dragged'
 DroppableArea:
     KXBoxLayout:
         orientation: 'tb'
@@ -32,7 +32,7 @@ DroppableArea:
     DraggableButton:
         size_hint: None, None
         size: 200, 200
-        allows_drag: allows_drag.active
+        drag_trigger: 'immediate' if allows_drag.active else 'none'
     Label:
         pos_hint: {'x': 0, 'top': 1, }
         size_hint: 1, .5

--- a/kivyx/uix/behaviors/dragreceiver.py
+++ b/kivyx/uix/behaviors/dragreceiver.py
@@ -26,7 +26,7 @@ __all__ = ('KXDragReceiver', )
 
 from contextlib import contextmanager
 
-from kivy.properties import NumericProperty, OptionProperty
+from kivy.properties import NumericProperty, OptionProperty, BooleanProperty
 from kivy.config import Config
 from kivy.factory import Factory
 import asynckivy as ak
@@ -121,7 +121,7 @@ class ClassicTrigger:
         recognized_as_drag = False
         ox, oy = touch.opos
         async for __ in ak.rest_of_touch_moves(
-                widget, touch, eats_touch=True):
+                widget, touch, eats_touch=widget.eats_touch):
             dx = abs(touch.x - ox)
             dy = abs(touch.y - oy)
             if dx > drag_distance or dy > drag_distance:
@@ -133,7 +133,7 @@ class ClassicTrigger:
             widget.dispatch('on_drag_touch_down', touch)
             widget.dispatch('on_drag_touch_move', touch)
             async for __ in ak.rest_of_touch_moves(
-                    widget, touch, eats_touch=True):
+                    widget, touch, eats_touch=widget.eats_touch):
                 widget.dispatch('on_drag_touch_move', touch)
             widget.dispatch('on_drag_touch_up', touch)
         else:
@@ -172,7 +172,7 @@ class LongPressTrigger:
         if touch.time_update != touch.time_start:
             widget.dispatch('on_drag_touch_move', touch)
         async for __ in ak.rest_of_touch_moves(
-                widget, touch, eats_touch=True):
+                widget, touch, eats_touch=widget.eats_touch):
             widget.dispatch('on_drag_touch_move', touch)
         widget.dispatch('on_drag_touch_up', touch)
 
@@ -183,7 +183,7 @@ class LongPressTrigger:
         drag_distance = widget.drag_distance
         ox, oy = touch.opos
         async for __ in ak.rest_of_touch_moves(
-                widget, touch, eats_touch=True):
+                widget, touch, eats_touch=widget.eats_touch):
             dx = abs(touch.x - ox)
             dy = abs(touch.y - oy)
             if dy > drag_distance or dx > drag_distance:
@@ -210,7 +210,7 @@ class ImmediateTrigger:
         widget = ctx['widget']
         widget.dispatch('on_drag_touch_down', touch)
         async for __ in ak.rest_of_touch_moves(
-                widget, touch, eats_touch=True):
+                widget, touch, eats_touch=widget.eats_touch):
             widget.dispatch('on_drag_touch_move', touch)
         widget.dispatch('on_drag_touch_up', touch)
 
@@ -249,6 +249,11 @@ class KXDragReceiver:
     'none'
         Touch will never be recognized as a dragging gesture,
         i.e. disables dragging gesture.
+    '''
+
+    eats_touch = BooleanProperty(False)
+    '''If True, when a touch is recognized as dragging gesture, it will never
+    be dispatched further.
     '''
 
     __events__ = (

--- a/kivyx/uix/behaviors/dragreceiver.py
+++ b/kivyx/uix/behaviors/dragreceiver.py
@@ -248,7 +248,7 @@ class KXDragReceiver:
 
     'none'
         Touch will never be recognized as a dragging gesture,
-        i.e. disables dragging gesture.
+        i.e. disable drag.
     '''
 
     eats_touch = BooleanProperty(False)

--- a/kivyx/uix/behaviors/dragreceiver.py
+++ b/kivyx/uix/behaviors/dragreceiver.py
@@ -12,21 +12,21 @@ It's your job to move a widget if you want to.
 (See `examples/uix/behaviors/dragreceiver/implementing_the_dragbehavior.py`)
 
 
-Regardning to `on_drag_is_about_to_start`:
+Regarding to `on_drag_is_about_to_start`:
 
-    This is fired when a touch satisfied the condition to be treated as drag,
-    and determines whether or not the touch actually will be. If one of the
-    callback functions returns truth-value, i.e.
+    This is fired when a touch satisfied the condition to be recognized as a
+    dragging gesture, and determines whether or not the touch actually will
+    be. If one of the callback functions returns truth-value, i.e.
     `self.dispatch('on_drag_is_about_to_start', touch)` returns truth-value,
-    the touch will be treated as non-drag. Keep in mind that this event is
-    fired during `on_touch_move`.
+    the touch will *not* be recognized as a dragging gesture. Keep in mind that
+    this event is fired during either of `on_touch_down` or `on_touch_move`.
 '''
 
 __all__ = ('KXDragReceiver', )
 
 from contextlib import contextmanager
 
-from kivy.properties import NumericProperty, BooleanProperty
+from kivy.properties import NumericProperty, OptionProperty
 from kivy.config import Config
 from kivy.factory import Factory
 import asynckivy as ak
@@ -47,23 +47,222 @@ def touch_context(touch):
         touch.pop()
 
 
+async def _simulate_normal_touch(ctx):
+    '''TODO: Need to check the change of the parent.
+    '''
+    sleep = ak.sleep
+    touch = ctx['touch']
+    widget = ctx['widget']
+    super_ = ctx['super']
+    window_to_parent = widget.parent.to_widget
+
+    await sleep(0)  # ensure the coordinates expressed in window coordinates
+
+    touch.grab_current = None
+    with touch_context(touch):
+        touch.apply_transform_2d(window_to_parent)
+        super_.on_touch_down(touch)
+
+    last_update = touch.time_update
+    has_moved = last_update != touch.time_start
+    has_ended = touch.time_end != -1
+    if not (has_moved or has_ended):
+        # no following touch events, no further simulation needed.
+        return
+    
+    await sleep(.1)
+
+    if has_ended:
+        touch.grab_current = None
+        with touch_context(touch):
+            touch.apply_transform_2d(window_to_parent)
+            super_.on_touch_up(touch)
+        # cleanup the grab_list as well
+        for x in touch.grab_list[:]:
+            touch.grab_list.remove(x)
+            x = x()
+            if x is None:
+                continue
+            touch.grab_current = x
+            with touch_context(touch):
+                touch.apply_transform_2d(x.parent.to_widget)
+                x.dispatch('on_touch_up', touch)
+        touch.grab_current = None
+        return
+
+    # check if any touch events was fired while sleeping
+    has_moved = touch.time_update != last_update
+    has_ended = touch.time_end != -1
+    if has_ended or has_moved:
+        return
+
+    touch.grab_current = None
+    with touch_context(touch):
+        touch.apply_transform_2d(window_to_parent)
+        super_.on_touch_move(touch)
+
+
+class ClassicTrigger:
+    @classmethod
+    def handle_touch(cls, ctx:dict):
+        touch = ctx['touch']
+        if touch.is_mouse_scrolling or \
+                (not ctx['widget'].collide_point(*touch.opos)):
+            return ctx['super'].on_touch_down(touch)
+        ctx['coro_main'] = ak.start(cls._main(ctx))
+        ctx['coro_cancel'] = ak.start(cls._cancel(ctx))
+        return True
+
+    @classmethod
+    async def _main(cls, ctx):
+        touch = ctx['touch']
+        widget = ctx['widget']
+        drag_distance = widget.drag_distance
+        recognized_as_drag = False
+        ox, oy = touch.opos
+        async for __ in ak.rest_of_touch_moves(
+                widget, touch, eats_touch=True):
+            dx = abs(touch.x - ox)
+            dy = abs(touch.y - oy)
+            if dx > drag_distance or dy > drag_distance:
+                if not widget.dispatch('on_drag_is_about_to_start', touch):
+                    recognized_as_drag = True
+                break
+        ctx['coro_cancel'].close()
+        if recognized_as_drag:
+            widget.dispatch('on_drag_touch_down', touch)
+            widget.dispatch('on_drag_touch_move', touch)
+            async for __ in ak.rest_of_touch_moves(
+                    widget, touch, eats_touch=True):
+                widget.dispatch('on_drag_touch_move', touch)
+            widget.dispatch('on_drag_touch_up', touch)
+        else:
+            ak.start(_simulate_normal_touch(ctx))
+
+    @classmethod
+    async def _cancel(cls, ctx):
+        await ak.sleep(ctx['widget'].drag_timeout / 1000.)
+        ctx['coro_main'].close()
+        ak.start(_simulate_normal_touch(ctx))
+
+
+class LongPressTrigger:
+    @classmethod
+    def handle_touch(cls, ctx:dict):
+        touch = ctx['touch']
+        if touch.is_mouse_scrolling or \
+                (not ctx['widget'].collide_point(*touch.opos)):
+            return ctx['super'].on_touch_down(touch)
+        ctx['coro_main'] = ak.start(cls._main(ctx))
+        ctx['coro_cancel'] = ak.start(cls._cancel(ctx))
+        return True
+
+    @classmethod
+    async def _main(cls, ctx):
+        touch = ctx['touch']
+        widget = ctx['widget']
+
+        await ak.sleep(widget.drag_timeout / 1000.)
+        ctx['coro_cancel'].close()
+        if widget.dispatch('on_drag_is_about_to_start', touch):
+            ak.start(_simulate_normal_touch(ctx))
+            return
+
+        widget.dispatch('on_drag_touch_down', touch)
+        if touch.time_update != touch.time_start:
+            widget.dispatch('on_drag_touch_move', touch)
+        async for __ in ak.rest_of_touch_moves(
+                widget, touch, eats_touch=True):
+            widget.dispatch('on_drag_touch_move', touch)
+        widget.dispatch('on_drag_touch_up', touch)
+
+    @classmethod
+    async def _cancel(cls, ctx):
+        touch = ctx['touch']
+        widget = ctx['widget']
+        drag_distance = widget.drag_distance
+        ox, oy = touch.opos
+        async for __ in ak.rest_of_touch_moves(
+                widget, touch, eats_touch=True):
+            dx = abs(touch.x - ox)
+            dy = abs(touch.y - oy)
+            if dy > drag_distance or dx > drag_distance:
+                break
+        ctx['coro_main'].close()
+        ak.start(_simulate_normal_touch(ctx))
+
+
+class ImmediateTrigger:
+    @classmethod
+    def handle_touch(cls, ctx:dict):
+        touch = ctx['touch']
+        widget = ctx['widget']
+        if touch.is_mouse_scrolling or \
+                (not widget.collide_point(*touch.opos)) or \
+                widget.dispatch('on_drag_is_about_to_start', touch):
+            return ctx['super'].on_touch_down(touch)
+        ak.start(cls._main(ctx))
+        return True
+
+    @classmethod
+    async def _main(cls, ctx):
+        touch = ctx['touch']
+        widget = ctx['widget']
+        widget.dispatch('on_drag_touch_down', touch)
+        async for __ in ak.rest_of_touch_moves(
+                widget, touch, eats_touch=True):
+            widget.dispatch('on_drag_touch_move', touch)
+        widget.dispatch('on_drag_touch_up', touch)
+
+
+class NoneTrigger:
+    @classmethod
+    def handle_touch(cls, ctx:dict):
+        return ctx['super'].on_touch_down(ctx['touch'])
+
+
 class KXDragReceiver:
     '''(See the module's document)'''
 
     drag_distance = NumericProperty(_scroll_distance)
-    '''Same as `DragBehavior.drag_distance`.'''
+    '''Same as DragBehavior's.'''
 
     drag_timeout = NumericProperty(_scroll_timeout)
-    '''Same as `DragBehavior.drag_timeout`.'''
+    '''Same as DragBehavior's.'''
 
-    allows_drag = BooleanProperty(True)
-    '''If False, touches are always treated as non-drag. Changing this value
-    doesn't affect ongoing touches.'''
+    drag_trigger = OptionProperty(
+        'classic',
+        options=('classic', 'long_press', 'immediate', 'none', ), )
+    '''Determines the way to distinguish a dragging gesture from a normal touch.
+
+    'classic'
+        Same as `DragBehavior`. If a touch travels `drag_distance` pixels
+        within the `drag_timeout` period, it is recognized as a dragging gesture.
+
+    'long_press'
+        If a touch stays for the `drag_timeout` period without traveling more
+        than `drag_distance` pixels, it is recognized as a dragging gesture.
+
+    'immediate'
+        Touch is immediately recognized as a dragging gesture.
+
+    'none'
+        Touch will never be recognized as a dragging gesture,
+        i.e. disables dragging gesture.
+    '''
 
     __events__ = (
         'on_drag_touch_down', 'on_drag_touch_move', 'on_drag_touch_up',
         'on_drag_is_about_to_start',
     )
+
+    _handle_touch_dict = {
+        'classic': ClassicTrigger.handle_touch,
+        'long_press': LongPressTrigger.handle_touch,
+        'immediate': ImmediateTrigger.handle_touch,
+        'none': NoneTrigger.handle_touch,
+    }
+    _handle_touch = _handle_touch_dict['classic']
 
     def on_drag_touch_down(self, touch):
         pass
@@ -77,95 +276,36 @@ class KXDragReceiver:
     def on_drag_is_about_to_start(self, touch):
         pass
 
+    def on_drag_trigger(self, __, value):
+        self._handle_touch = self._handle_touch_dict[value]
+
     def on_touch_down(self, touch):
-        if (not self.allows_drag) or \
-                touch.is_mouse_scrolling or \
-                (not self.collide_point(*touch.opos)):
-            return super().on_touch_down(touch)
-        ctx = {}
-        ctx['coro_main'] = ak.start(self.__handle_touch(ctx, touch))
-        ctx['coro_cancel'] = ak.start(self.__cancel_drag(ctx, touch))
-        return True
-
-    async def __handle_touch(self, ctx, touch):
-        from kivy.metrics import sp
-        drag_distance = sp(self.drag_distance)
-        handles_as_drag = False
-        needs_to_emulate_touch_up = True
-        async for __ in ak.rest_of_touch_moves(self, touch):
-            if not handles_as_drag:
-                dx = abs(touch.x - touch.ox)
-                dy = abs(touch.y - touch.oy)
-                if dx > drag_distance or dy > drag_distance:
-                    if self.dispatch('on_drag_is_about_to_start', touch):
-                        needs_to_emulate_touch_up = False
-                        break
-                    handles_as_drag = True
-                    ctx['coro_cancel'].close()
-                    self.dispatch('on_drag_touch_down', touch)
-            if handles_as_drag:
-                self.dispatch('on_drag_touch_move', touch)
-        if handles_as_drag:
-            self.dispatch('on_drag_touch_up', touch)
-            ctx.clear()
-            return
-        ctx['coro_cancel'].close()
-        ctx.clear()
-        touch.grab_current = None
-        super().on_touch_down(touch)
-        touch.grab_current = self
-        if not needs_to_emulate_touch_up:
-            return
-        await ak.sleep(0)
-        with touch_context(touch):
-            touch.apply_transform_2d(self.parent.to_widget)
-            super().on_touch_up(touch)
-        for x in touch.grab_list[:]:
-            touch.grab_list.remove(x)
-            x = x()
-            if not x:
-                continue
-            touch.grab_current = x
-            with touch_context(touch):
-                touch.apply_transform_2d(x.parent.to_widget)
-                x.dispatch('on_touch_up', touch)
-        touch.grab_current = None
-
-    async def __cancel_drag(self, ctx, touch):
-        await ak.sleep(self.drag_timeout / 1000.)
-        ctx['coro_main'].close()
-        ctx.clear()
-        with touch_context(touch):
-            touch.apply_transform_2d(self.parent.to_widget)
-            super().on_touch_down(touch)
+        return self._handle_touch(
+            {'widget': self, 'touch': touch, 'super': super(), }
+        )
 
     async def rest_of_drag_touch_moves(self, touch):
         '''The drag version of `asynckivy.rest_of_touch_moves()`.'''
         from asynckivy._core import _get_step_coro
         from asynckivy._rest_of_touch_moves \
-            import _true_if_touch_up_false_if_touch_move
+            import _true_if_touch_move_false_if_touch_up
         step_coro = await _get_step_coro()
-        def _on_touch_up(w, t):
-            if t.grab_current is w and t is touch:
-                step_coro(True)
-                return True
-        def _on_touch_move(w, t):
-            if t.grab_current is w and t is touch:
+        def _on_drag_touch_up(w, t):
+            if t is touch:
                 step_coro(False)
-                return True
-        uid_up = self.fbind('on_drag_touch_up', _on_touch_up)
-        uid_move = self.fbind('on_drag_touch_move', _on_touch_move)
+        def _on_drag_touch_move(w, t):
+            if t is touch:
+                step_coro(True)
+        uid_up = self.fbind('on_drag_touch_up', _on_drag_touch_up)
+        uid_move = self.fbind('on_drag_touch_move', _on_drag_touch_move)
         assert uid_up
         assert uid_move
 
         try:
-            while True:
-                if await _true_if_touch_up_false_if_touch_move():
-                    return
+            while await _true_if_touch_move_false_if_touch_up():
                 yield touch
         finally:
             self.unbind_uid('on_drag_touch_up', uid_up)
             self.unbind_uid('on_drag_touch_move', uid_move)
-
 
 Factory.register('KXDragReceiver', cls=KXDragReceiver)

--- a/kivyx/uix/draggable.py
+++ b/kivyx/uix/draggable.py
@@ -240,6 +240,7 @@ class KXDraggableScreenManager(KXDragReceiver, ScreenManager):
         # mark the touch so that KXDroppableBehavior can react
         touch_ud['kivyx_drag_cls'] = self.drag_cls
 
+        pos = None
         async for __ in self.rest_of_drag_touch_moves(touch):
             pos = touch.pos
             self.pos = (pos[0] - offset_x, pos[1] - offset_y)

--- a/kivyx/uix/draggable.py
+++ b/kivyx/uix/draggable.py
@@ -16,7 +16,7 @@ __all__ = (
 
 from kivy.properties import (
     ObjectProperty, NumericProperty, BooleanProperty, ListProperty,
-    StringProperty,
+    StringProperty, OptionProperty,
 )
 from kivy.clock import Clock
 from kivy.lang import Builder
@@ -303,10 +303,18 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
     '''The differences from KXDraggable.
 
     - Faster.
-    - Doesn't have `on_drag_is_about_to_start` event.
-    - Immediately treats touches as drag if it happens inside the widget.
+    - Supports only two types of drag triggers. ('none' and 'immediate')
     '''
-    __events__ = ('on_drag_start', 'on_drag_complete', 'on_drag_cancel', )
+    __events__ = (
+        'on_drag_is_about_to_start',
+        'on_drag_start', 'on_drag_complete', 'on_drag_cancel',
+    )
+
+    drag_trigger = OptionProperty('immediate', options=('immediate', 'none'))
+    '''See `KXDragReceiver`'s documentation. '''
+
+    eats_touch = BooleanProperty(False)
+    '''Same as `KXDragReceiver`'s '''
 
     drag_cls = StringProperty()
     '''Same as KXDraggable's '''
@@ -326,9 +334,6 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
     duration_of_cancel_anim = NumericProperty(.1)
     '''Same as KXDraggable's '''
 
-    allows_drag = BooleanProperty(True)
-    '''Same as KXDragReceiver's '''
-
     # some methods are completely the same as KXDraggable's, so use it.
     __on_pos = KXDraggable._KXDraggable__on_pos
     __on_size = KXDraggable._KXDraggable__on_size
@@ -337,17 +342,23 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
 
     def __init__(self, **kwargs):
         f = self.fbind
+        f('on_drag_is_about_to_start', KXModestDraggable.__on_drag_is_about_to_start)
         f('pos', KXModestDraggable.__on_pos)
         f('size', KXModestDraggable.__on_size)
         f('widget_default', KXModestDraggable.__on_widget_default)
         super().__init__(**kwargs)
 
+    def __on_drag_is_about_to_start(self, touch):
+        return (
+            self.drag_trigger == 'none' or 
+            self.is_being_dragged or
+            self.widget_default is None or
+            touch.is_mouse_scrolling or
+            (not self.collide_point(*touch.opos))
+        )
+
     def on_touch_down(self, touch):
-        if (not self.allows_drag) or \
-                self.is_being_dragged or \
-                (not self.widget_default) or \
-                touch.is_mouse_scrolling or \
-                (not self.collide_point(*touch.opos)):
+        if self.dispatch('on_drag_is_about_to_start', touch):
             return super().on_touch_down(touch)
         self.is_being_dragged = True
         self.dispatch('on_drag_start')
@@ -396,7 +407,8 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
         # mark the touch so that KXDroppableBehavior can react
         touch_ud['kivyx_drag_cls'] = self.drag_cls
 
-        async for __ in ak.rest_of_touch_moves(self, touch):
+        async for __ in ak.rest_of_touch_moves(
+                self, touch, eats_touch=self.eats_touch):
             touch_pos_win = self_to_window(*touch.pos)
             widget_below_finger.pos = (
                 touch_pos_win[0] - offset_x,
@@ -428,6 +440,9 @@ class KXModestDraggable(KXFakeChildrenBehavior, Widget):
             droppable.accept_drag(self)
             self.dispatch('on_drag_complete', droppable=droppable)
         self.is_being_dragged = False
+
+    def on_drag_is_about_to_start(self, touch):
+        pass
 
     def on_drag_start(self):
         pass


### PR DESCRIPTION
By this pr, `KXDragReceiver` has the following options to initiate drag

- `classic` ... Same as the `DragBehavior`
- `long_press` ... initiated by long press
- `immediate` ... initiated immediately
- `none` ... disables drag