### PR TITLE
Allows the user to interleave a dragging process with any code including awaitables

### DIFF
--- a/examples/uix/behaviors/draggable/_test_reorderable_gridlayout.py
+++ b/examples/uix/behaviors/draggable/_test_reorderable_gridlayout.py
@@ -9,8 +9,6 @@ import kivyx.uix.behaviors.draggable
 
 
 KV_CODE = '''
-#:import Spacer kivyx.uix.behaviors.draggable.KXReorderablesDefaultSpacer
-
 <ReorderableGridLayout@KXReorderableBehavior+GridLayout>:
 <DraggableItem@KXDraggableBehavior+KXMagnet>:
     do_anim: not self.is_being_dragged
@@ -132,11 +130,8 @@ BoxLayout:
         cols: int(n_cols.value) or None
         rows: int(n_rows.value) or None
         spacer_widgets:
-            [
-            Spacer(size_hint_min=(50, 50, ), color="#0000FF44"),
-            Spacer(size_hint_min=(50, 50, ), color="#00FF0022"),
-            Spacer(size_hint_min=(50, 50, ), color="#FF000044"),
-            ]
+            [self.create_spacer(color=color)
+            for color in "#000044 #002200 #440000".split()]
 '''
 root = Builder.load_string(KV_CODE)
 gl = root.ids.gl

--- a/examples/uix/behaviors/draggable/classifying_food.py
+++ b/examples/uix/behaviors/draggable/classifying_food.py
@@ -62,7 +62,7 @@ class DraggableLabel(KXDraggableBehavior, Factory.Label):
             return
         print(f"Incorrect! {self.text} is not {droppable.color_cls}")
 
-    def on_drag_complete(self, droppable):
+    def on_drag_success(self, droppable):
         print("Correct")
 
 

--- a/examples/uix/behaviors/draggable/classifying_food.py
+++ b/examples/uix/behaviors/draggable/classifying_food.py
@@ -5,9 +5,7 @@ from kivy.factory import Factory
 import asynckivy as ak
 
 from kivyx.uix.boxlayout import KXBoxLayout
-from kivyx.uix.behaviors.draggable import (
-    KXDroppableBehavior, KXDraggableBehavior,
-)
+from kivyx.uix.behaviors.draggable import KXDroppableBehavior, KXDraggableBehavior
 
 
 KV_CODE = '''

--- a/examples/uix/behaviors/draggable/classifying_food.py
+++ b/examples/uix/behaviors/draggable/classifying_food.py
@@ -59,15 +59,14 @@ KXBoxLayout:
 class DraggableLabel(KXDraggableBehavior, Factory.Label):
     color_cls = StringProperty()
 
-    def on_drag_fail(self, ctx):
-        r = super().on_drag_fail(ctx)
-        if ctx.drag_to is not None:
-            print(f"Incorrect! {self.text} is not {ctx.drag_to.color_cls}")
-        return r
+    def on_drag_fail(self, touch, ctx):
+        if ctx.droppable is not None:
+            print(f"Incorrect! {self.text} is not {ctx.droppable.color_cls}")
+        return super().on_drag_fail(touch, ctx)
 
-    async def on_drag_success(self, ctx):
+    async def on_drag_success(self, touch, ctx):
         print("Correct")
-        self.center = self.to_window(*ctx.drag_to.center)
+        self.center = self.to_window(*ctx.droppable.center)
         await ak.animate(self, opacity=0, d=.5)
         self.parent.remove_widget(self)
         
@@ -76,10 +75,10 @@ class DroppableArea(KXDroppableBehavior, Factory.FloatLayout):
     line_color = ColorProperty()
     color_cls = StringProperty()
 
-    def will_accept_drag(self, draggable, ctx):
-        return draggable.color_cls == self.color_cls
+    def will_accept_drag(self, touch, ctx):
+        return ctx.draggable.color_cls == self.color_cls
 
-    def accept_drag(self, draggable, ctx):
+    def accept_drag(self, touch, ctx):
         pass
 
 

--- a/examples/uix/behaviors/draggable/draggable_travels_around_multiple_droppables.py
+++ b/examples/uix/behaviors/draggable/draggable_travels_around_multiple_droppables.py
@@ -6,8 +6,6 @@ import kivyx.uix.magnet
 import kivyx.uix.behaviors.draggable
 
 KV_CODE = '''
-#:import Spacer kivyx.uix.behaviors.draggable.KXReorderablesDefaultSpacer
-
 <DraggableItem@KXDraggableBehavior+KXMagnet>:
     do_anim: not self.is_being_dragged
     text: ''
@@ -46,11 +44,8 @@ BoxLayout:
         spacing: 10
         drag_classes: ['test', ]
         spacer_widgets:
-            [
-            Spacer(size_hint_min=(50, 50, ), color="#FF000044"),
-            Spacer(size_hint_min=(50, 50, ), color="#00FF0022"),
-            Spacer(size_hint_min=(50, 50, ), color="#0000FF44"),
-            ]
+            [self.create_spacer(color=color)
+            for color in "#000044 #002200 #440000".split()]
     GridLayout:
         id: center_layout
         cols: 2
@@ -63,11 +58,8 @@ BoxLayout:
         spacing: 10
         drag_classes: ['test', ]
         spacer_widgets:
-            [
-            Spacer(size_hint_min=(50, 50, ), color="#FF000044"),
-            Spacer(size_hint_min=(50, 50, ), color="#00FF0022"),
-            Spacer(size_hint_min=(50, 50, ), color="#0000FF44"),
-            ]
+            [self.create_spacer(color=color)
+            for color in "#000044 #002200 #440000".split()]
 '''
 root = Builder.load_string(KV_CODE)
 

--- a/examples/uix/behaviors/draggable/flutter_style_draggable.py
+++ b/examples/uix/behaviors/draggable/flutter_style_draggable.py
@@ -74,7 +74,7 @@ class FlutterStyleDraggable(KXDraggableBehavior, Factory.ScreenManager):
             w = self.get_screen('childWhenDragging')
             if w.parent is not None:
                 w.parent.remove_widget(w)
-    on_drag_complete = on_drag_fail
+    on_drag_success = on_drag_fail
 
 
 class Cell(KXDroppableBehavior, Factory.FloatLayout):

--- a/examples/uix/behaviors/draggable/flutter_style_draggable.py
+++ b/examples/uix/behaviors/draggable/flutter_style_draggable.py
@@ -61,24 +61,31 @@ class FlutterStyleDraggable(KXDraggableBehavior, Factory.ScreenManager):
     def __on_is_being_dragged(self, value):
         self.current = 'feedback' if value else 'child'
 
-    def on_drag_start(self):
+    def on_drag_start(self, ctx):
         from kivyx.utils import restore_widget_location
         if self.has_screen('childWhenDragging'):
             restore_widget_location(
                 self.get_screen('childWhenDragging'),
-                self.dragged_from,
+                ctx.drag_from,
             )
 
-    def on_drag_fail(self, droppable):
+    def on_drag_fail(self, ctx):
         if self.has_screen('childWhenDragging'):
             w = self.get_screen('childWhenDragging')
             if w.parent is not None:
                 w.parent.remove_widget(w)
-    on_drag_success = on_drag_fail
+        return super().on_drag_fail(ctx)
+
+    def on_drag_success(self, ctx):
+        if self.has_screen('childWhenDragging'):
+            w = self.get_screen('childWhenDragging')
+            if w.parent is not None:
+                w.parent.remove_widget(w)
+        return super().on_drag_success(ctx)
 
 
 class Cell(KXDroppableBehavior, Factory.FloatLayout):
-    def will_accept_drag(self, draggable):
+    def will_accept_drag(self, draggable, ctx):
         return not self.children
 
     def add_widget(self, widget, *args, **kwargs):

--- a/examples/uix/behaviors/draggable/flutter_style_draggable.py
+++ b/examples/uix/behaviors/draggable/flutter_style_draggable.py
@@ -61,31 +61,32 @@ class FlutterStyleDraggable(KXDraggableBehavior, Factory.ScreenManager):
     def __on_is_being_dragged(self, value):
         self.current = 'feedback' if value else 'child'
 
-    def on_drag_start(self, ctx):
+    def on_drag_start(self, touch, ctx):
         from kivyx.utils import restore_widget_location
         if self.has_screen('childWhenDragging'):
             restore_widget_location(
                 self.get_screen('childWhenDragging'),
-                ctx.drag_from,
+                ctx.original_location,
             )
+        return super().on_drag_start(touch, ctx)
 
-    def on_drag_fail(self, ctx):
+    def on_drag_fail(self, touch, ctx):
         if self.has_screen('childWhenDragging'):
             w = self.get_screen('childWhenDragging')
             if w.parent is not None:
                 w.parent.remove_widget(w)
-        return super().on_drag_fail(ctx)
+        return super().on_drag_fail(touch, ctx)
 
-    def on_drag_success(self, ctx):
+    def on_drag_success(self, touch, ctx):
         if self.has_screen('childWhenDragging'):
             w = self.get_screen('childWhenDragging')
             if w.parent is not None:
                 w.parent.remove_widget(w)
-        return super().on_drag_success(ctx)
+        return super().on_drag_success(touch, ctx)
 
 
 class Cell(KXDroppableBehavior, Factory.FloatLayout):
-    def will_accept_drag(self, draggable, ctx):
+    def will_accept_drag(self, touch, ctx):
         return not self.children
 
     def add_widget(self, widget, *args, **kwargs):

--- a/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
+++ b/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
@@ -65,8 +65,8 @@ class Droppable(KXDroppableBehavior, Label):
         super().__init__(**kwargs)
         self._ud_key = 'Droppable.' + str(self.uid)
 
-    def accept_drag(self, draggable, ctx):
-        draggable.parent.remove_widget(draggable)
+    def accept_drag(self, touch, ctx):
+        ctx.draggable.parent.remove_widget(ctx.draggable)
 
     def on_touch_move(self, touch):
         ud_key = self._ud_key

--- a/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
+++ b/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
@@ -65,7 +65,7 @@ class Droppable(KXDroppableBehavior, Label):
         super().__init__(**kwargs)
         self._ud_key = 'Droppable.' + str(self.uid)
 
-    def accept_drag(self, draggable, **kwargs):
+    def accept_drag(self, draggable, ctx):
         draggable.parent.remove_widget(draggable)
 
     def on_touch_move(self, touch):

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -355,6 +355,7 @@ class KXDroppableBehavior:
         return True
 
     def accept_drag(self, draggable, ctx):
+        drag_from = ctx.drag_from
         draggable.parent.remove_widget(draggable)
         draggable.size_hint_x = drag_from['size_hint_x']
         draggable.size_hint_y = drag_from['size_hint_y']

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -46,6 +46,7 @@ from kivy.properties import (
 from kivy.lang import Builder
 from kivy.factory import Factory
 from kivy.uix.widget import Widget
+from asyncgui.exceptions import InvalidStateError
 import asynckivy as ak
 
 from kivyx.utils import save_widget_location, restore_widget_location
@@ -56,10 +57,6 @@ _scroll_timeout = _scroll_distance = 0
 if Config:
     _scroll_timeout = Config.getint('widgets', 'scroll_timeout')
     _scroll_distance = Config.get('widgets', 'scroll_distance') + 'sp'
-
-
-class DraggableException(Exception):
-    pass
 
 
 @contextmanager
@@ -408,7 +405,7 @@ class KXReorderableBehavior:
 
     def on_spacer_widgets(self, __, spacer_widgets):
         if self._active_spacers:
-            raise DraggableException(
+            raise InvalidStateError(
                 "Do not change the 'spacer_widgets' when there is an ongoing"
                 " drag.")
         self._inactive_spacers = [w.__self__ for w in spacer_widgets]

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -94,9 +94,6 @@ class DragContext:
     droppable: Union[None, 'KXDroppableBehavior', 'KXReorderableBehavior'] = None
     '''The widget where the draggable dropped to.'''
 
-    droppable_index: Union[None, int] = None
-    '''The new child-index of the draggable.'''
-
 
 class KXDraggableBehavior:
     __events__ = ('on_drag_start', 'on_drag_success', 'on_drag_fail', )
@@ -221,7 +218,6 @@ class KXDraggableBehavior:
                     await r
                 await ak.sleep(-1)
             else:
-                ctx.droppable_index = touch_ud.get('kivyx_droppable_index', 0)
                 droppable.accept_drag(touch, ctx)
                 r = self.dispatch('on_drag_success', touch, ctx)
                 if isawaitable(r):
@@ -304,7 +300,7 @@ class KXDroppableBehavior:
         draggable.size_hint_x = original_location['size_hint_x']
         draggable.size_hint_y = original_location['size_hint_y']
         draggable.pos_hint = original_location['pos_hint']
-        self.add_widget(draggable, index=ctx.droppable_index)
+        self.add_widget(draggable, index=touch.ud.get('kivyx_droppable_index', 0))
 
 
 class KXReorderableBehavior:

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -43,6 +43,7 @@ from kivy.properties import (
     BooleanProperty, ListProperty, StringProperty, ColorProperty,
     NumericProperty, OptionProperty,
 )
+from kivy.clock import Clock
 from kivy.factory import Factory
 from kivy.uix.widget import Widget
 from asyncgui.exceptions import InvalidStateError
@@ -395,14 +396,14 @@ class KXReorderableBehavior:
     def __init__(self, **kwargs):
         self._active_spacers = []
         self._inactive_spacers = None
-        self.bind(on_kv_post=self._on_kv_post)
+        Clock.schedule_once(self._init_spacers)
         super().__init__(**kwargs)
         self.__ud_key = 'KXReorderableBehavior.' + str(self.uid)
 
     will_accept_drag = KXDroppableBehavior.will_accept_drag
     accept_drag = KXDroppableBehavior.accept_drag
 
-    def _on_kv_post(self, *args, **kwargs):
+    def _init_spacers(self, dt):
         if self._inactive_spacers is None:
             self.spacer_widgets.append(self.create_spacer())
 

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -89,7 +89,7 @@ Builder.load_string('''
 
 
 class KXDraggableBehavior:
-    __events__ = ('on_drag_start', 'on_drag_complete', 'on_drag_fail', )
+    __events__ = ('on_drag_start', 'on_drag_success', 'on_drag_fail', )
 
     drag_cls = StringProperty()
     '''Same as drag_n_drop's '''
@@ -220,7 +220,7 @@ class KXDraggableBehavior:
                     desired_index=touch_ud.get('kivyx_droppable_index', 0),
                     drag_from=dragged_from,
                 )
-                self.dispatch('on_drag_complete', droppable=droppable)
+                self.dispatch('on_drag_success', droppable=droppable)
         finally:
             self.is_being_dragged = False
             self._dragged_from = None
@@ -266,7 +266,7 @@ class KXDraggableBehavior:
     def on_drag_start(self):
         pass
 
-    def on_drag_complete(self, droppable: Widget):
+    def on_drag_success(self, droppable: Widget):
         pass
 
     def on_drag_fail(self, droppable: Optional[Widget]):

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -397,10 +397,11 @@ class KXReorderableBehavior:
         get_drop_insertion_index_move = self.get_drop_insertion_index_move
         remove_widget = self.remove_widget
         add_widget = self.add_widget
+        touch_ud = touch.ud
 
         try:
             restore_widget_location(
-                spacer, touch.ud['kivyx_drag_from'],
+                spacer, touch_ud['kivyx_drag_from'],
                 ignore_parent=True)
             add_widget(spacer)
             async for __ in ak.rest_of_touch_moves(self, touch):
@@ -411,11 +412,11 @@ class KXReorderableBehavior:
                         remove_widget(spacer)
                         add_widget(spacer, index=new_idx)
                 else:
-                    del touch.ud[self.__ud_key]
+                    del touch_ud[self.__ud_key]
                     return
-            ud_setdefault = touch.ud.setdefault
-            ud_setdefault('kivyx_droppable', self)
-            ud_setdefault('kivyx_droppable_index', self.children.index(spacer))
+            if 'kivyx_droppable' not in touch_ud:
+                touch_ud['kivyx_droppable'] = self
+                touch_ud['kivyx_droppable_index'] = self.children.index(spacer)
         finally:
             self.remove_widget(spacer)
             self._inactive_spacers.append(spacer)

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -290,10 +290,10 @@ class KXDroppableBehavior:
                 touch_ud.setdefault('kivyx_droppable', self)
         return r
 
-    def will_accept_drag(self, touch, ctx) -> bool:
+    def will_accept_drag(self, touch, ctx: DragContext) -> bool:
         return True
 
-    def accept_drag(self, touch, ctx):
+    def accept_drag(self, touch, ctx: DragContext):
         draggable = ctx.draggable
         original_location = ctx.original_location
         draggable.parent.remove_widget(draggable)

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -200,7 +200,7 @@ class KXDraggableBehavior:
 
             # mark the touch so that the other widgets can react to the drag
             touch_ud['kivyx_drag_cls'] = self.drag_cls
-            touch_ud['kivyx_drag_from'] = original_location
+            touch_ud['kivyx_drag_ctx'] = ctx
 
             self.dispatch('on_drag_start', touch, ctx)
             async for __ in ak.rest_of_touch_moves(self, touch):
@@ -397,7 +397,7 @@ class KXReorderableBehavior:
 
         try:
             restore_widget_location(
-                spacer, touch_ud['kivyx_drag_from'],
+                spacer, touch_ud['kivyx_drag_ctx'].original_location,
                 ignore_parent=True)
             add_widget(spacer)
             async for __ in ak.rest_of_touch_moves(self, touch):

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -31,7 +31,6 @@ Main differences from drag_n_drop
 
 __all__ = (
     'KXDraggableBehavior', 'KXDroppableBehavior', 'KXReorderableBehavior',
-    'KXBaseDraggableBehavior',
 )
 from typing import Tuple, Optional
 from contextlib import contextmanager
@@ -96,7 +95,7 @@ class DragContext:
     '''The new child-index of the draggable.'''
 
 
-class KXBaseDraggableBehavior:
+class KXDraggableBehavior:
     __events__ = ('on_drag_start', 'on_drag_success', 'on_drag_fail', )
 
     drag_cls = StringProperty()
@@ -268,76 +267,13 @@ class KXBaseDraggableBehavior:
     def on_drag_success(self, ctx: DragContext):
         pass
 
-    def on_drag_fail(self, ctx: DragContext):
-        pass
-
-
-class PredefinedActions:
-    def _predefined_actions():
-        async def goback_anim(draggable, ctx):
-            await ak.animate(
-                draggable, d=.1,
-                x=ctx.original_pos_win[0],
-                y=ctx.original_pos_win[1],
-            )
-            restore_widget_location(draggable, ctx.drag_from)
-
-        def goback(draggable, ctx):
-            restore_widget_location(draggable, ctx.drag_from)
-
-        async def disappear_anim(draggable, ctx):
-            original_opacity = draggable.opacity
-            try:
-                await ak.animate(draggable, d=1, opacity=0)
-            finally:
-                draggable.opacity = original_opacity
-            draggable.parent.remove_widget(draggable)
-
-        def disappear(draggable, ctx):
-            draggable.parent.remove_widget(draggable)
-
-        def none(draggable, ctx):
-            pass
-
-        return {
-            'goback_anim': goback_anim,
-            'goback': goback,
-            'disappear_anim': disappear_anim,
-            'disappear': disappear,
-            'none': none,
-        }
-    _predefined_actions = _predefined_actions()
-
-    action_on_drag_fail = \
-        OptionProperty('goback_anim', options=_predefined_actions.keys())
-    '''Determines which action will be triggered when 'on_drag_fail' is fired.
-
-    * goback .. The draggable goes back to where it came from.
-    * goback_anim .. The draggable goes back to where it came from with an animation.
-    * disappear .. The draggable disappears.
-    * disappear_anim .. The draggable disappears with an animation.
-    * none .. Does nothing.
-
-    Defaults to 'goback_anim'.
-    '''
-
-    action_on_drag_success = \
-        OptionProperty('none', options=_predefined_actions.keys())
-    '''Determines which action will be triggered when 'on_drag_success' is
-    fired. See ``action_on_drag_fail``'s doc.
-
-    Defaults to 'none'.
-    '''
-
-    def on_drag_success(self, ctx):
-        return self._predefined_actions[self.action_on_drag_success](self, ctx)
-
-    def on_drag_fail(self, ctx):
-        return self._predefined_actions[self.action_on_drag_fail](self, ctx)
-
-
-class KXDraggableBehavior(PredefinedActions, KXBaseDraggableBehavior):
-    pass
+    async def on_drag_fail(self, ctx: DragContext):
+        await ak.animate(
+            self, d=.1,
+            x=ctx.original_pos_win[0],
+            y=ctx.original_pos_win[1],
+        )
+        restore_widget_location(self, ctx.drag_from)
 
 
 class KXDroppableBehavior:
@@ -479,7 +415,6 @@ class KXReorderableBehavior:
 
 
 r = Factory.register
-r('KXBaseDraggableBehavior', cls=KXBaseDraggableBehavior)
 r('KXDraggableBehavior', cls=KXDraggableBehavior)
 r('KXDroppableBehavior', cls=KXDroppableBehavior)
 r('KXReorderableBehavior', cls=KXReorderableBehavior)

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -177,7 +177,7 @@ class KXDraggableBehavior:
             ctx = DragContext(
                 original_pos_win=original_pos_win,
                 original_location=original_location,
-                draggable=self.proxy_ref,
+                draggable=self,
             )
 
             if do_transform:

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -188,7 +188,10 @@ class KXDraggableBehavior:
             self.parent.remove_widget(self)
             self.size_hint = (None, None, )
             self.pos_hint = {}
-            self.pos = original_pos_win
+            self.pos = (
+                original_pos_win[0] + touch.x - touch.ox,
+                original_pos_win[1] + touch.y - touch.oy,
+            )
             window.add_widget(self)
 
             # mark the touch so that the other widgets can react to the drag


### PR DESCRIPTION
The second step of redesigning the drag & drop functionality.

## customizing animation

By default, when the user failed to drag, the draggable will go back to where it came from with an animation, like what web browsers do on desktop. This is because the default handler of `on_drag_fail` is defined as follows:

```python
class KXDraggableBehavior:
    async def on_drag_fail(self, touch, ctx: DragContext):
        await ak.animate(
            self, d=.1,
            x=ctx.original_pos_win[0],
            y=ctx.original_pos_win[1],
        )
        restore_widget_location(self, ctx.original_location)
```

You can customize it, e.g. If you don't need the animation, overwrite it as follows:

```python
class YourDraggable(KXDraggableBehavior, SomeWidget):
    def on_drag_fail(self, touch, ctx: DragContext):
        restore_widget_location(self, ctx.original_location)
```

You may notice that `on_drag_fail` supports both async-function and regular-function. This is the motive of the PR. You can interleave a draggaing process with your code **including awaitables**. Which is very different from just startting a coroutine as follows:

```python
class YourDraggable(KXDraggableBehavior, SomeWidget):
    def on_drag_fail(self, touch, ctx: DragContext):
        ak.start(self._on_drag_fail(touch, ctx))
    async def _on_drag_fail(self, touch, ctx: DragContext):
        await ak.animate(
            self, d=.1,
            x=ctx.original_pos_win[0],
            y=ctx.original_pos_win[1],
        )
        restore_widget_location(self, ctx.original_location)
```

In this case, `_on_drag_fail()` might outlive the dragging process since it's excuted concurrently, which is not desirable. But if you define the default handler like the first example, the returned coroutine will be awaited immediately in the draggaing process because of:

```python
# This is how the draggaing process handles the return-value of `dispatch()`

                r = self.dispatch('on_drag_fail', touch, ctx)
                if isawaitable(r):
                    await r
```

So the returned coroutine never outlives the caller (the draggging process), which is desirable.

*NOTE: Only the default handler of `on_drag_success` and `on_drag_fail` is allowed to return an awaitable.*

## other examples

```python
# When the user failed to drag, the draggable will fade-out and will disappear.

class YourDraggable(KXDraggableBehavior, SomeWidget):
    async def on_drag_fail(self, touch, ctx):
        draggable = ctx.draggable
        await ak.animate(draggable, d=1, opacity=0)
        draggable.parent.remove_widget(draggable)
```

```python
# When the user failed to drag, the draggable will just disappear with no animation.

class YourDraggable(KXDraggableBehavior, SomeWidget):
    def on_drag_fail(self, touch, ctx):
        draggable = ctx.draggable
        draggable.parent.remove_widget(draggable)
```

```python
# When the user failed to drag, the draggable will do nothing and will stay there

class YourDraggable(KXDraggableBehavior, SomeWidget):
    def on_drag_fail(self, touch, ctx):
        pass
```

## list of breaking changes

- remove `KXDraggableBehavior.dragged_from`
- rename `on_drag_complete` -> `on_drag_success`
- `InvalidStateError` instead of `DraggableException`
- event signiture

```python
class KXBaseDraggableBehavior:
    def on_drag_start(self, touch, ctx: DragContext):
        pass

    def on_drag_success(self, touch, ctx: DragContext):
        pass

    def on_drag_fail(self, touch, ctx: DragContext):
        pass
```

- method signiture

```python
class KXDroppableBehavior:
    def will_accept_drag(self, touch, ctx: DragContext) -> bool:
        pass

    def accept_drag(self, touch, ctx: DragContext):
        pass

class KXReorderableBehavior:
    def will_accept_drag(self, touch, ctx: DragContext) -> bool:
        pass

    def accept_drag(self, touch, ctx: DragContext):
        pass
```