### PR TITLE
make the drag & drop functionality cancellable

### DIFF
--- a/examples/uix/behaviors/draggable/cancelling_ongoing_drags.py
+++ b/examples/uix/behaviors/draggable/cancelling_ongoing_drags.py
@@ -1,0 +1,85 @@
+from kivy.app import App
+from kivy.lang import Builder
+from kivy.factory import Factory
+
+from kivyx.utils import restore_widget_location
+import kivyx.uix.magnet
+from kivyx.uix.behaviors.draggable import KXDraggableBehavior
+
+
+KV_CODE = '''
+<ReorderableGridLayout@KXReorderableBehavior+GridLayout>:
+<DraggableItem@KXDraggableBehavior+KXMagnet>:
+    do_anim: not self.is_being_dragged
+    text: ''
+    anim_duration: .3
+    drag_cls: 'test'
+    drag_timeout: 0
+    opacity: .5 if self.is_being_dragged else 1.
+    size_hint_min: 50, 50
+    pos_hint: {'center_x': .5, 'center_y': .5, }
+    canvas.after:
+        Color:
+            rgba: .5, 1, 0, 1 if root.is_being_dragged else .5
+        Line:
+            width: 2 if root.is_being_dragged else 1
+            rectangle: [*self.pos, *self.size, ]
+    Label:
+        font_size: 30
+        text: root.text
+<MyButton@Button>:
+    font_size: sp(30)
+    size_hint_min_x: self.texture_size[0] + dp(10)
+    size_hint_min_y: self.texture_size[1] + dp(10)
+
+BoxLayout:
+    spacing: 10
+    padding: 10
+    orientation: 'vertical'
+    ReorderableGridLayout:
+        id: gl
+        spacing: 10
+        drag_classes: ['test', ]
+        cols: 6
+        spacer_widgets:
+            [self.create_spacer(color=color)
+            for color in "#000044 #002200 #440000".split()]
+    BoxLayout:
+        spacing: 10
+        orientation: 'vertical'
+        size_hint_y: None
+        height: self.minimum_height
+        MyButton:
+            text: 'dispose all draggables currently being dragged'
+            on_press: app.dispose_ongoing_drags()
+        MyButton:
+            text: 'cancel all drags'
+            on_press: app.cancel_ongoing_drags()
+'''
+
+
+class SampleApp(App):
+    def build(self):
+        return Builder.load_string(KV_CODE)
+
+    def on_start(self):
+        gl = self.root.ids.gl
+        DraggableItem = Factory.DraggableItem
+        DraggableItem()
+        for i in range(23):
+            gl.add_widget(DraggableItem(text=str(i)))
+
+    def dispose_ongoing_drags(self):
+        for draggable in tuple(KXDraggableBehavior.ongoing_drags()):
+            draggable.cancel_drag()
+            draggable.parent.remove_widget(draggable)
+
+    def cancel_ongoing_drags(self):
+        for draggable in tuple(KXDraggableBehavior.ongoing_drags()):
+            original_location = draggable.drag_ctx.original_location
+            draggable.cancel_drag()
+            restore_widget_location(draggable, original_location)
+
+
+if __name__ == '__main__':
+    SampleApp().run()

--- a/examples/uix/behaviors/draggable/cancelling_ongoing_drags.py
+++ b/examples/uix/behaviors/draggable/cancelling_ongoing_drags.py
@@ -76,7 +76,7 @@ class SampleApp(App):
 
     def cancel_ongoing_drags(self):
         for draggable in tuple(KXDraggableBehavior.ongoing_drags()):
-            original_location = draggable.drag_ctx.original_location
+            original_location = draggable.drag_context.original_location
             draggable.cancel_drag()
             restore_widget_location(draggable, original_location)
 

--- a/examples/uix/behaviors/draggable/classifying_food.py
+++ b/examples/uix/behaviors/draggable/classifying_food.py
@@ -57,14 +57,15 @@ KXBoxLayout:
 class DraggableLabel(KXDraggableBehavior, Factory.Label):
     color_cls = StringProperty()
 
-    def on_drag_fail(self, touch, ctx):
+    def on_drag_fail(self, touch):
+        ctx = self.drag_ctx
         if ctx.droppable is not None:
             print(f"Incorrect! {self.text} is not {ctx.droppable.color_cls}")
-        return super().on_drag_fail(touch, ctx)
+        return super().on_drag_fail(touch)
 
-    async def on_drag_success(self, touch, ctx):
+    async def on_drag_success(self, touch):
         print("Correct")
-        self.center = self.to_window(*ctx.droppable.center)
+        self.center = self.to_window(*self.drag_ctx.droppable.center)
         await ak.animate(self, opacity=0, d=.5)
         self.parent.remove_widget(self)
         
@@ -73,8 +74,8 @@ class DroppableArea(KXDroppableBehavior, Factory.FloatLayout):
     line_color = ColorProperty()
     color_cls = StringProperty()
 
-    def accepts_drag(self, touch, ctx):
-        return ctx.draggable.color_cls == self.color_cls
+    def accepts_drag(self, touch, draggable):
+        return draggable.color_cls == self.color_cls
 
 
 class SampleApp(App):

--- a/examples/uix/behaviors/draggable/classifying_food.py
+++ b/examples/uix/behaviors/draggable/classifying_food.py
@@ -58,14 +58,14 @@ class DraggableLabel(KXDraggableBehavior, Factory.Label):
     color_cls = StringProperty()
 
     def on_drag_fail(self, touch):
-        ctx = self.drag_ctx
+        ctx = self.drag_context
         if ctx.droppable is not None:
             print(f"Incorrect! {self.text} is not {ctx.droppable.color_cls}")
         return super().on_drag_fail(touch)
 
     async def on_drag_success(self, touch):
         print("Correct")
-        self.center = self.to_window(*self.drag_ctx.droppable.center)
+        self.center = self.to_window(*self.drag_context.droppable.center)
         await ak.animate(self, opacity=0, d=.5)
         self.parent.remove_widget(self)
         

--- a/examples/uix/behaviors/draggable/classifying_food.py
+++ b/examples/uix/behaviors/draggable/classifying_food.py
@@ -73,7 +73,7 @@ class DroppableArea(KXDroppableBehavior, Factory.FloatLayout):
     line_color = ColorProperty()
     color_cls = StringProperty()
 
-    def will_accept_drag(self, touch, ctx):
+    def accepts_drag(self, touch, ctx):
         return ctx.draggable.color_cls == self.color_cls
 
 

--- a/examples/uix/behaviors/draggable/classifying_food.py
+++ b/examples/uix/behaviors/draggable/classifying_food.py
@@ -76,9 +76,6 @@ class DroppableArea(KXDroppableBehavior, Factory.FloatLayout):
     def will_accept_drag(self, touch, ctx):
         return ctx.draggable.color_cls == self.color_cls
 
-    def accept_drag(self, touch, ctx):
-        pass
-
 
 class SampleApp(App):
     def build(self):

--- a/examples/uix/behaviors/draggable/flutter_style_draggable.py
+++ b/examples/uix/behaviors/draggable/flutter_style_draggable.py
@@ -61,32 +61,32 @@ class FlutterStyleDraggable(KXDraggableBehavior, Factory.ScreenManager):
     def __on_is_being_dragged(self, value):
         self.current = 'feedback' if value else 'child'
 
-    def on_drag_start(self, touch, ctx):
+    def on_drag_start(self, touch):
         from kivyx.utils import restore_widget_location
         if self.has_screen('childWhenDragging'):
             restore_widget_location(
                 self.get_screen('childWhenDragging'),
-                ctx.original_location,
+                self.drag_ctx.original_location,
             )
-        return super().on_drag_start(touch, ctx)
+        return super().on_drag_start(touch)
 
-    def on_drag_fail(self, touch, ctx):
+    def on_drag_fail(self, touch):
         if self.has_screen('childWhenDragging'):
             w = self.get_screen('childWhenDragging')
             if w.parent is not None:
                 w.parent.remove_widget(w)
-        return super().on_drag_fail(touch, ctx)
+        return super().on_drag_fail(touch)
 
-    def on_drag_success(self, touch, ctx):
+    def on_drag_success(self, touch):
         if self.has_screen('childWhenDragging'):
             w = self.get_screen('childWhenDragging')
             if w.parent is not None:
                 w.parent.remove_widget(w)
-        return super().on_drag_success(touch, ctx)
+        return super().on_drag_success(touch)
 
 
 class Cell(KXDroppableBehavior, Factory.FloatLayout):
-    def accepts_drag(self, touch, ctx):
+    def accepts_drag(self, touch, draggable):
         return not self.children
 
     def add_widget(self, widget, *args, **kwargs):

--- a/examples/uix/behaviors/draggable/flutter_style_draggable.py
+++ b/examples/uix/behaviors/draggable/flutter_style_draggable.py
@@ -86,7 +86,7 @@ class FlutterStyleDraggable(KXDraggableBehavior, Factory.ScreenManager):
 
 
 class Cell(KXDroppableBehavior, Factory.FloatLayout):
-    def will_accept_drag(self, touch, ctx):
+    def accepts_drag(self, touch, ctx):
         return not self.children
 
     def add_widget(self, widget, *args, **kwargs):

--- a/examples/uix/behaviors/draggable/flutter_style_draggable.py
+++ b/examples/uix/behaviors/draggable/flutter_style_draggable.py
@@ -66,7 +66,7 @@ class FlutterStyleDraggable(KXDraggableBehavior, Factory.ScreenManager):
         if self.has_screen('childWhenDragging'):
             restore_widget_location(
                 self.get_screen('childWhenDragging'),
-                self.drag_ctx.original_location,
+                self.drag_context.original_location,
             )
         return super().on_drag_start(touch)
 

--- a/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
+++ b/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
@@ -60,7 +60,7 @@ KXBoxLayout:
 
 
 class Draggable(KXDraggableBehavior, Label):
-    def on_drag_success(self, touch, ctx):
+    def on_drag_success(self, touch):
         self.parent.remove_widget(self)
 
 

--- a/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
+++ b/examples/uix/behaviors/draggable/reacting_to_entering_and_leaving.py
@@ -21,7 +21,7 @@ KV_CODE = '''
             pos: self.pos
             size: self.size
 
-<Draggable@KXDraggableBehavior+Label>:
+<Draggable>:
     drag_timeout: 0
     text: root.drag_cls
     font_size: 50
@@ -58,15 +58,18 @@ KXBoxLayout:
             drag_cls: 'B'
 '''
 
+
+class Draggable(KXDraggableBehavior, Label):
+    def on_drag_success(self, touch, ctx):
+        self.parent.remove_widget(self)
+
+
 class Droppable(KXDroppableBehavior, Label):
     n_ongoing_drags_inside = NumericProperty(0)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._ud_key = 'Droppable.' + str(self.uid)
-
-    def accept_drag(self, touch, ctx):
-        ctx.draggable.parent.remove_widget(ctx.draggable)
 
     def on_touch_move(self, touch):
         ud_key = self._ud_key

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -24,8 +24,7 @@ Main differences from drag_n_drop
   stays for ``drag_timeout`` milli seconds without traveling more than
   ``drag_distance`` pixels, it will be treated as a dragging gesture.
 * :class:`KXReorderableBehavior` can handle multiple drags simultaneously.
-* Drag can be cancelled by calling ``KXDraggableBehavior.cancel_drag()`` or
-  ``KXDraggableBehavior.cancel_drag_safely()``.
+* Drag can be cancelled by calling ``KXDraggableBehavior.cancel_drag()``.
 * ``KXReorderableBehavior`` cannot be put inside another one if their
   ``drag_classes``s is overlapping each other.
 
@@ -130,7 +129,7 @@ class KXDraggableBehavior:
         )
 
     @property
-    def drag_ctx(self) -> Union[None, DragContext]:
+    def drag_context(self) -> Union[None, DragContext]:
         return self._drag_ctx
 
     def cancel_drag(self):
@@ -440,7 +439,7 @@ class KXReorderableBehavior:
 
         try:
             restore_widget_location(
-                spacer, touch_ud['kivyx_draggable'].drag_ctx.original_location,
+                spacer, touch_ud['kivyx_draggable'].drag_context.original_location,
                 ignore_parent=True)
             add_widget(spacer)
             async for __ in ak.rest_of_touch_moves(self, touch):

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -91,9 +91,14 @@ class DragContext:
     droppable: Union[None, 'KXDroppableBehavior', 'KXReorderableBehavior'] = None
     '''(read-only) The widget where the draggable dropped to.'''
 
+    cancelled: bool = False
+    '''(read-only) Indicates whether the drag was cancelled or not.'''
+
 
 class KXDraggableBehavior:
-    __events__ = ('on_drag_start', 'on_drag_success', 'on_drag_fail', )
+    __events__ = (
+        'on_drag_start', 'on_drag_end', 'on_drag_success', 'on_drag_fail',
+    )
 
     drag_cls = StringProperty()
     '''Same as drag_n_drop's '''
@@ -238,7 +243,11 @@ class KXDraggableBehavior:
             if isawaitable(r):
                 await r
             await ak.sleep(-1)
+        except GeneratorExit:
+            ctx.cancelled = True
+            raise
         finally:
+            self.dispatch('on_drag_end', touch)
             self.is_being_dragged = False
             self._drag_ctx = None
             del touch_ud['kivyx_drag_cls']
@@ -283,6 +292,9 @@ class KXDraggableBehavior:
         return
 
     def on_drag_start(self, touch):
+        pass
+
+    def on_drag_end(self, touch):
         pass
 
     def on_drag_success(self, touch):

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -213,7 +213,7 @@ class KXDraggableBehavior:
             ctx.droppable = droppable = touch_ud.get('kivyx_droppable', None)
             touch_ud['kivyx_droppable'] = None
             failed = droppable is None or \
-                not droppable.will_accept_drag(touch, ctx)
+                not droppable.accepts_drag(touch, ctx)
             r = self.dispatch(
                 'on_drag_fail' if failed else 'on_drag_success', touch, ctx)
             if isawaitable(r):
@@ -292,7 +292,7 @@ class KXDroppableBehavior:
                 touch_ud.setdefault('kivyx_droppable', self)
         return r
 
-    def will_accept_drag(self, touch, ctx: DragContext) -> bool:
+    def accepts_drag(self, touch, ctx: DragContext) -> bool:
         return True
 
 
@@ -332,7 +332,7 @@ class KXReorderableBehavior:
         super().__init__(**kwargs)
         self.__ud_key = 'KXReorderableBehavior.' + str(self.uid)
 
-    will_accept_drag = KXDroppableBehavior.will_accept_drag
+    accepts_drag = KXDroppableBehavior.accepts_drag
 
     def _init_spacers(self, dt):
         if self._inactive_spacers is None:

--- a/kivyx/uix/behaviors/draggable.py
+++ b/kivyx/uix/behaviors/draggable.py
@@ -25,8 +25,8 @@ Main differences from drag_n_drop
   ``drag_distance`` pixels, it will be treated as a dragging gesture.
 * :class:`KXReorderableBehavior` can handle multiple drags simultaneously.
 * Drag can be cancelled by calling ``KXDraggableBehavior.cancel_drag()``.
-* ``KXReorderableBehavior`` cannot be put inside another one if their
-  ``drag_classes``s is overlapping each other.
+* Nested ``KXReorderableBehavior`` is not officially supported. It may or may
+  not work depending on how ``drag_classes`` and ``drag_cls`` are set.
 
 .. _drag_n_drop (Kivy Garden): https://github.com/kivy-garden/drag_n_drop
 .. _Flutter: https://api.flutter.dev/flutter/widgets/Draggable-class.html


### PR DESCRIPTION
The 3rd step of redesigning the drag & drop functionality

# list of changes

- remove `accept_drag()`. Its role was taken by `KXDraggableBehavior.on_drag_success()`
- rename  `will_accept_drag()` ->`accepts_drag()`
- remove `DragContext.draggable`
- add `KXDraggableBehavior.drag_context` property
- make a drag cancellable (`KXDraggableBehavior.cancel_drag()`)
- event signiture (again)

```python
class KXBaseDraggableBehavior:
    def on_drag_start(self, touch):
        pass

    def on_drag_end(self, touch):
        pass

    def on_drag_success(self, touch):
        pass

    def on_drag_fail(self, touch):
        pass
```

- method signiture (again)

```python
class KXDroppableBehavior:
    def accepts_drag(self, touch, draggable) -> bool:
        pass


class KXReorderableBehavior:
    def accepts_drag(self, touch, draggable) -> bool:
        pass
```